### PR TITLE
Adds the fluke banner also to the help of main fluke cmd

### DIFF
--- a/fluke/run.py
+++ b/fluke/run.py
@@ -31,11 +31,23 @@ __version__ = "0.7.2"
 console = Console()
 
 
+def fluke_banner():
+    fluke_pretty = "    ██████  ████             █████              "
+    fluke_pretty += "\n   ███░░███░░███            ░░███               "
+    fluke_pretty += "\n  ░███ ░░░  ░███  █████ ████ ░███ █████  ██████ "
+    fluke_pretty += "\n ███████    ░███ ░░███ ░███  ░███░░███  ███░░███"
+    fluke_pretty += "\n░░░███░     ░███  ░███ ░███  ░██████░  ░███████ "
+    fluke_pretty += "\n  ░███      ░███  ░███ ░███  ░███░░███ ░███░░░  "
+    fluke_pretty += "\n  █████     █████ ░░████████ ████ █████░░██████ "
+    fluke_pretty += "\n ░░░░░     ░░░░░   ░░░░░░░░ ░░░░ ░░░░░  ░░░░░░ "
+    console.print(Panel(fluke_pretty,
+                  subtitle=f"v{__version__}", style="bold white"), width=52)
+
+
 def version_callback(value: bool):
     if value:
         print(f"fluke: {__version__}")
         raise typer.Exit()
-
 
 app = typer.Typer()
 
@@ -253,18 +265,19 @@ def clients_only(exp_cfg: str = typer.Argument(..., help="Configuration file"),
 @app.callback()
 def run(version: bool = typer.Option(None, "--version", help="Show the installed version of fluke",
                                      callback=version_callback)) -> None:
+    """
+    \b
+        ██████  ████             █████
+       ███░░███░░███            ░░███
+      ░███ ░░░  ░███  █████ ████ ░███ █████  ██████
+     ███████    ░███ ░░███ ░███  ░███░░███  ███░░███
+    ░░░███░     ░███  ░███ ░███  ░██████░  ░███████
+      ░███      ░███  ░███ ░███  ░███░░███ ░███░░░
+      █████     █████ ░░████████ ████ █████░░██████
+     ░░░░░     ░░░░░   ░░░░░░░░ ░░░░ ░░░░░  ░░░░░░
+    """
 
-    fluke_pretty = "    ██████  ████             █████              "
-    fluke_pretty += "\n   ███░░███░░███            ░░███               "
-    fluke_pretty += "\n  ░███ ░░░  ░███  █████ ████ ░███ █████  ██████ "
-    fluke_pretty += "\n ███████    ░███ ░░███ ░███  ░███░░███  ███░░███"
-    fluke_pretty += "\n░░░███░     ░███  ░███ ░███  ░██████░  ░███████ "
-    fluke_pretty += "\n  ░███      ░███  ░███ ░███  ░███░░███ ░███░░░  "
-    fluke_pretty += "\n  █████     █████ ░░████████ ████ █████░░██████ "
-    fluke_pretty += "\n ░░░░░     ░░░░░   ░░░░░░░░ ░░░░ ░░░░░  ░░░░░░ "
-    console.print(Panel(fluke_pretty,
-                  subtitle=f"v{__version__}", style="bold white"), width=52)
-    pass
+    fluke_banner()
 
 
 def main() -> Any:


### PR DESCRIPTION
Current implementation shows the fluke banner only on the --help invocation of subcommands. This change makes the banner to appear also on the main fluke command (i.e., on invocation of `fluke --help`).

It is not perfect (it does not include the panel border and the version number), probably it can be added with a bit of meta-programming, but this is quick and dirty and goes 95% of the way.