### PR TITLE
Improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.DS_Store
+.venv/
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Use an official Python runtime as a base image
+FROM python:3.12-slim
+
+# Optional: create a non-root user (recommended for production)
+# RUN useradd -ms /bin/bash appuser
+# USER appuser
+
+# Install your library from PyPI
+RUN pip install fluke-fl
+
+# Default command (optional)
+CMD ["python3"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fluke-fl?style=for-the-badge&logo=python&logoColor=yellow)
 ![GitHub License](https://img.shields.io/github/license/makgyver/fluke?style=for-the-badge)
 [![arXiv](https://img.shields.io/badge/arxiv-2412.15728-b31b1b.svg?style=for-the-badge&logo=arxiv&logoColor=red)](https://arxiv.org/abs/2412.15728)
+![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
 
 # **fluke**: **f**ederated **l**earning **u**tility framewor**k** for **e**xperimentation and research
 
@@ -10,12 +11,29 @@
 
 ## Installation
 
+### Pypi
+
 ``fluke`` is a Python package that can be installed via pip. To install it, you can run the following command:
 
 ```bash
 pip install fluke-fl
 ```
 
+### 🐳 Docker
+
+You can use this library directly inside a Docker container — no installation needed on your local machine.
+
+```bash
+docker build -t fluke_container .
+```
+
+Then, you can run an interactive session with
+
+```bash
+docker run --rm fluke_container fluke [ARGS]
+```
+
+where `ARGS` are the arguments you want to pass to the `fluke` command as described in the next section.
 
 ## Run a federated algorithm
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 project = 'fluke'
 copyright = '2024, Mirko Polato'
 author = 'Mirko Polato'
-version = '0.7.2'
+version = '0.7.3'
 # release = 'alpha'
 
 # autodoc_mock_imports = ['algorithms'] # Fix the "No module named 'algorithms'" error

--- a/fluke/__init__.py
+++ b/fluke/__init__.py
@@ -40,6 +40,13 @@ __all__ = [
     'Singleton'
 ]
 
+__version__ = '0.7.3'
+__author__ = 'Mirko Polato'
+__email__ = 'mirko.polato@unito.it'
+__license__ = 'LGPLv2.1'
+__copyright__ = 'Copyright (c) 2025, Mirko Polato'
+__status__ = 'Development'
+
 
 class Singleton(type):
     """This metaclass is used to create singleton classes. A singleton class is a class that can

--- a/fluke/__init__.py
+++ b/fluke/__init__.py
@@ -11,7 +11,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Iterable, Union
-
+from omegaconf import DictConfig
 import numpy as np
 import torch
 from diskcache import Cache
@@ -119,7 +119,7 @@ class DDict(dict):
         for arg in args:
             if isinstance(arg, dict):
                 for k, v in arg.items():
-                    if isinstance(v, dict):
+                    if isinstance(v, (dict, DictConfig)):
                         self[k] = DDict(**v)
                     else:
                         self[k] = v
@@ -127,7 +127,7 @@ class DDict(dict):
                 warnings.warn(f"Argument {arg} is not a dictionary and will be ignored.")
 
         for k, v in kwargs.items():
-            if isinstance(v, dict):
+            if isinstance(v, (dict, DictConfig)):
                 self[k] = DDict(**v)
             else:
                 self[k] = v

--- a/fluke/__init__.py
+++ b/fluke/__init__.py
@@ -394,9 +394,6 @@ class FlukeENV(metaclass=Singleton):
             torch.backends.cudnn.benchmark = False
             torch.backends.cudnn.deterministic = True
 
-        # import os
-        # os.environ['PYTHONHASHSEED'] = str(seed)
-
     def auto_device(self) -> torch.device:
         """Set device to ``cuda`` or ``mps`` if available, otherwise ``cpu``.
 
@@ -593,6 +590,12 @@ class FlukeCache():
                 str: The unique identifier.
             """
             return self._id
+
+        def __str__(self) -> str:
+            return f"_ObjectRef({self._id})"
+
+        def __repr__(self):
+            return self.__str__()
 
     class _RefCounter():
         """A reference counter for an object in the cache."""

--- a/fluke/algorithms/__init__.py
+++ b/fluke/algorithms/__init__.py
@@ -105,7 +105,9 @@ class CentralizedFL(ServerObserver):
                  **kwargs: dict[str, Any]):
         self._id = str(uuid.uuid4().hex)
         FlukeENV().open_cache(self._id)
-        self.hyper_params = hyper_params if isinstance(hyper_params, DDict) else DDict(hyper_params)
+        if isinstance(hyper_params, dict):
+            hyper_params = DDict(hyper_params)
+        self.hyper_params = hyper_params
         self.n_clients = n_clients
         (clients_tr_data, clients_te_data), server_data = \
             data_splitter.assign(n_clients, hyper_params.client.batch_size)
@@ -226,7 +228,10 @@ class CentralizedFL(ServerObserver):
             data (FastDataLoader): The server-side test set.
             config (DDict): Configuration of the server.
         """
-        self.server: Server = self.get_server_class()(model, data, self.clients, **config)
+        self.server: Server = self.get_server_class()(model=model,
+                                                      test_set=data,
+                                                      clients=self.clients,
+                                                      **config)
         if FlukeENV().get_save_options()[0] is not None:
             self.server.attach(self)
 

--- a/fluke/algorithms/fedamp.py
+++ b/fluke/algorithms/fedamp.py
@@ -102,7 +102,8 @@ class FedAMPServer(Server):
                  test_set: FastDataLoader,  # not used
                  clients: Iterable[PFLClient],
                  sigma: float = 0.1,
-                 alpha: float = 0.1):
+                 alpha: float = 0.1,
+                 **kwargs: dict[str, Any]):
         super().__init__(model=model, test_set=None, clients=clients, weighted=False)
         self.hyper_params.update(
             sigma=sigma,

--- a/fluke/algorithms/fedbabu.py
+++ b/fluke/algorithms/fedbabu.py
@@ -44,7 +44,6 @@ class FedBABUClient(Client):
                          optimizer_cfg=optimizer_cfg, loss_fn=loss_fn, local_epochs=local_epochs,
                          fine_tuning_epochs=fine_tuning_epochs, clipping=clipping, **kwargs)
         self.hyper_params.update(mode=mode)
-        self._load_from_cache()
         self.model = model
         self._save_to_cache()
 

--- a/fluke/algorithms/fedhp.py
+++ b/fluke/algorithms/fedhp.py
@@ -8,7 +8,7 @@ References:
 """
 import copy
 import sys
-from typing import Any, Iterable, Literal, Generator
+from typing import Any, Generator, Iterable, Literal
 
 import torch
 import torch.optim as optim

--- a/fluke/algorithms/fedrep.py
+++ b/fluke/algorithms/fedrep.py
@@ -56,7 +56,6 @@ class FedRepClient(Client):
                          test_set=test_set, optimizer_cfg=optimizer_cfg, loss_fn=loss_fn,
                          local_epochs=local_epochs, fine_tuning_epochs=fine_tuning_epochs,
                          clipping=clipping, **kwargs)
-        self._load_from_cache()
         if isinstance(model, str):
             model = get_model(model)
         self._modopt = _ModOpt2(model=EncoderGlobalHeadLocalNet(model))

--- a/fluke/algorithms/lg_fedavg.py
+++ b/fluke/algorithms/lg_fedavg.py
@@ -50,7 +50,6 @@ class LGFedAVGClient(Client):
         super().__init__(index=index, train_set=train_set,
                          test_set=test_set, optimizer_cfg=optimizer_cfg, loss_fn=loss_fn,
                          local_epochs=local_epochs, fine_tuning_epochs=fine_tuning_epochs, **kwargs)
-        self._load_from_cache()
         self.model = HeadGlobalEncoderLocalNet(model)
         self._save_to_cache()
 

--- a/fluke/evaluation.py
+++ b/fluke/evaluation.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Optional, Union
 import numpy as np
 import torch
 from torch.nn import Module
-from torchmetrics import Accuracy, F1Score, Precision, Recall
+from torchmetrics import Accuracy, F1Score, Precision, Recall, Metric
 
 sys.path.append(".")
 sys.path.append("..")
@@ -99,9 +99,43 @@ class ClassificationEval(Evaluator):
         n_classes (int): The number of classes.
     """
 
-    def __init__(self, eval_every: int, n_classes: int):
+    def __init__(self, eval_every: int, n_classes: int, **metrics: dict[str, Metric]):
         super().__init__(eval_every=eval_every)
         self.n_classes: int = n_classes
+
+        self._metrics = {}
+
+        # if kwargs is empty
+        if not metrics:
+            self._metrics = {
+                "accuracy":         Accuracy(task="multiclass", num_classes=self.n_classes,
+                                             top_k=1),
+                "macro_precision":  Precision(task="multiclass", num_classes=self.n_classes,
+                                              top_k=1, average="macro"),
+                "macro_recall":     Recall(task="multiclass", num_classes=self.n_classes,
+                                           top_k=1, average="macro"),
+                "macro_f1":         F1Score(task="multiclass", num_classes=self.n_classes,
+                                            top_k=1, average="macro"),
+                "micro_precision":  Precision(task="multiclass", num_classes=self.n_classes,
+                                              top_k=1, average="micro"),
+                "micro_recall":     Recall(task="multiclass", num_classes=self.n_classes,
+                                           top_k=1, average="micro"),
+                "micro_f1":         F1Score(task="multiclass", num_classes=self.n_classes,
+                                            top_k=1, average="micro")
+            }
+        else:
+            self._metrics = metrics
+
+    def add_metric(self, name: str, metric: Metric) -> None:
+        """Add a metric to the evaluator.
+
+        Args:
+            name (str): The name of the metric.
+            metric (Metric): The metric to add.
+        """
+        if name in self._metrics:
+            raise ValueError(f"Metric {name} already exists.")
+        self._metrics[name] = metric
 
     @torch.no_grad
     def evaluate(self,
@@ -146,25 +180,17 @@ class ClassificationEval(Evaluator):
             model_device = next(model.parameters()).device
         model.eval()
         model.to(device)
-        task = "multiclass"  # if self.n_classes >= 2 else "binary"
-        accs, losses = [], []
-        micro_precs, micro_recs, micro_f1s = [], [], []
-        macro_precs, macro_recs, macro_f1s = [], [], []
+        losses = []
+        matrics_values = {k: [] for k in self._metrics.keys()}
         loss, cnt = 0, 0
 
         if not isinstance(eval_data_loader, list):
             eval_data_loader = [eval_data_loader]
 
         for data_loader in eval_data_loader:
-            accuracy = Accuracy(task=task, num_classes=self.n_classes, top_k=1, average="micro")
-            micro_precision = Precision(
-                task=task, num_classes=self.n_classes, top_k=1, average="micro")
-            micro_recall = Recall(task=task, num_classes=self.n_classes, top_k=1, average="micro")
-            micro_f1 = F1Score(task=task, num_classes=self.n_classes, top_k=1, average="micro")
-            macro_precision = Precision(
-                task=task, num_classes=self.n_classes, top_k=1, average="macro")
-            macro_recall = Recall(task=task, num_classes=self.n_classes, top_k=1, average="macro")
-            macro_f1 = F1Score(task=task, num_classes=self.n_classes, top_k=1, average="macro")
+            for metric in self._metrics.values():
+                metric.reset()
+
             loss = 0
             for X, y in data_loader:
                 X, y = X.to(device), y.to(device)
@@ -173,36 +199,19 @@ class ClassificationEval(Evaluator):
                     if loss_fn is not None:
                         loss += loss_fn(y_hat, y).item()
 
-                accuracy.update(y_hat.cpu(), y.cpu())
-                micro_precision.update(y_hat.cpu(), y.cpu())
-                micro_recall.update(y_hat.cpu(), y.cpu())
-                micro_f1.update(y_hat.cpu(), y.cpu())
-                macro_precision.update(y_hat.cpu(), y.cpu())
-                macro_recall.update(y_hat.cpu(), y.cpu())
-                macro_f1.update(y_hat.cpu(), y.cpu())
+                for metric in self._metrics.values():
+                    metric.update(y_hat.cpu(), y.cpu())
 
             cnt += len(data_loader)
-            accs.append(accuracy.compute().item())
-            micro_precs.append(micro_precision.compute().item())
-            micro_recs.append(micro_recall.compute().item())
-            micro_f1s.append(micro_f1.compute().item())
-            macro_precs.append(macro_precision.compute().item())
-            macro_recs.append(macro_recall.compute().item())
-            macro_f1s.append(macro_f1.compute().item())
+
+            for k, v in self._metrics.items():
+                matrics_values[k].append(v.compute().item())
             losses.append(loss / cnt)
 
         model.to(model_device)
         clear_cuda_cache()
 
-        result = {
-            "accuracy":  np.round(sum(accs) / len(accs), 5).item(),
-            "micro_precision": np.round(sum(micro_precs) / len(micro_precs), 5).item(),
-            "micro_recall":    np.round(sum(micro_recs) / len(micro_recs), 5).item(),
-            "micro_f1":        np.round(sum(micro_f1s) / len(micro_f1s), 5).item(),
-            "macro_precision": np.round(sum(macro_precs) / len(macro_precs), 5).item(),
-            "macro_recall":    np.round(sum(macro_recs) / len(macro_recs), 5).item(),
-            "macro_f1":        np.round(sum(macro_f1s) / len(macro_f1s), 5).item()
-        }
+        result = {m: np.round(sum(v) / len(v), 5).item() for m, v in matrics_values.items()}
 
         if loss_fn is not None:
             result["loss"] = np.round(sum(losses) / len(losses), 5).item()
@@ -211,7 +220,7 @@ class ClassificationEval(Evaluator):
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}(eval_every={self.eval_every}" + \
-            f", n_classes={self.n_classes})[accuracy, precision, recall, f1]"
+            f", n_classes={self.n_classes})[{', '.join(self._metrics.keys())}]"
 
     def __repr__(self) -> str:
         return str(self)

--- a/fluke/run.py
+++ b/fluke/run.py
@@ -19,6 +19,7 @@ from .utils import (Configuration, OptimizerConfigurator,  # NOQA
                     get_class_from_qualified_name, get_loss, get_model)
 
 console = Console()
+app = typer.Typer()
 
 
 def fluke_banner():
@@ -33,9 +34,6 @@ def version_callback(value: bool):
     if value:
         print(f"fluke: {__version__}")
         raise typer.Exit()
-
-
-app = typer.Typer()
 
 
 def _compose_config(cfg_base: str, overrides: Optional[List[str]]) -> DictConfig:

--- a/fluke/server.py
+++ b/fluke/server.py
@@ -194,6 +194,7 @@ class Server(ObserverSubject):
                     break
 
                 except EarlyStopping:
+                    self._notify_early_stop()
                     break
 
             progress_fl.remove_task(task_rounds)
@@ -413,6 +414,12 @@ class Server(ObserverSubject):
         """
         for observer in self._observers:
             observer.interrupted()
+
+    def _notify_early_stop(self) -> None:
+        """Notify the observers that the federated learning process has been stopped early.
+        """
+        for observer in self._observers:
+            observer.early_stop(self.rounds + 1)
 
     def _notify_track_item(self, item: str, value: Any) -> None:
         """Notify the observers that an item has been tracked.

--- a/fluke/server.py
+++ b/fluke/server.py
@@ -28,7 +28,6 @@ torch.serialization.add_safe_globals([set])
 
 
 class EarlyStopping(Exception):
-
     """Exception raised when the fedearted training process is stopped early.
 
     This exception is used to signal that the training process should be stopped early.

--- a/fluke/utils/__init__.py
+++ b/fluke/utils/__init__.py
@@ -196,6 +196,15 @@ class ServerObserver():
         """This method is called when the federated learning process has been interrupted."""
         pass
 
+    def early_stop(self, round: int) -> None:
+        """This method is called when the federated learning process has been stopped due to an
+        early stopping criterion.
+
+        Args:
+            round (int): The last round number.
+        """
+        pass
+
     def track_item(self,
                    round: int,
                    item: str,

--- a/fluke/utils/log.py
+++ b/fluke/utils/log.py
@@ -231,10 +231,13 @@ class Log(ServerObserver, ChannelObserver, ClientObserver):
         rich_print(Panel(Pretty({"comm_costs": sum(self.comm_costs.values())}, expand_all=True),
                          title="Total communication cost", width=100))
 
-    def interrupted(self):
+    def interrupted(self) -> None:
         rich_print("\n[bold italic yellow]The experiment has been interrupted by the user.")
 
-    def track_item(self, round, item, value):
+    def early_stop(self, round: int) -> None:
+        return self.end_round(round)
+
+    def track_item(self, round, item, value) -> None:
         self.add_scalar(item, value, round)
 
     def save(self, path: str) -> None:
@@ -248,7 +251,9 @@ class Log(ServerObserver, ChannelObserver, ClientObserver):
             "comm_costs": self.comm_costs,
             "perf_locals": self.locals_eval_summary,
             "perf_prefit": self.prefit_eval_summary,
-            "perf_postfit": self.postfit_eval_summary
+            "perf_postfit": self.postfit_eval_summary,
+            "mem_costs": self.mem_costs,
+            "custom_fields": self.custom_fields
         }
         with open(path, 'w') as f:
             json.dump(json_to_save, f, indent=4)

--- a/fluke/utils/log.py
+++ b/fluke/utils/log.py
@@ -21,7 +21,7 @@ import wandb
 sys.path.append(".")
 sys.path.append("..")
 
-from .. import DDict, FlukeENV  # NOQA
+from .. import DDict  # NOQA
 from ..comm import ChannelObserver, Message  # NOQA
 from ..utils import bytes2human, get_class_from_qualified_name  # NOQA
 from . import ClientObserver, ServerObserver, get_class_from_str  # NOQA
@@ -29,6 +29,7 @@ from . import ClientObserver, ServerObserver, get_class_from_str  # NOQA
 
 __all__ = [
     "Log",
+    "DebugLog",
     "TensorboardLog",
     "WandBLog",
     "ClearMLLog",
@@ -61,7 +62,7 @@ class Log(ServerObserver, ChannelObserver, ClientObserver):
         self.locals_eval_summary: dict = {}  # round -> evals (mean across clients)
         self.prefit_eval_summary: dict = {}  # round -> evals (mean across clients)
         self.postfit_eval_summary: dict = {}  # round -> evals (mean across clients)
-        self.comm_costs: dict = {0: 0}
+        self.comm_costs: dict = {0: 0}  # round -> comm_cost
         self.mem_costs: dict = {}
         self.current_round: int = 0
         self.custom_fields: dict = {}
@@ -571,7 +572,7 @@ def get_logger(lname: str, **kwargs: dict[str, Any]) -> Log:
         **kwargs: The keyword arguments to pass to the logger's constructor.
 
     Returns:
-        Log | WandBLog | ClearMLLog | TensorboardLog: The logger.
+        Log | DebugLog | WandBLog | ClearMLLog | TensorboardLog: The logger.
     """
     if "." in lname and not lname.startswith("fluke.utils.log"):
         return get_class_from_qualified_name(lname)(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 license = "LGPL-2.1-or-later"
 license-files = ["LICENSE"]
 name = "fluke-fl"
-version = "0.7.2"
+version = "0.7.3"
 authors = [
   { name="Mirko Polato", email="mirko.polato@unito.it" }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ matplotlib
 seaborn
 opacus
 diskcache
+hydra-core
+cerberus

--- a/tests/configs/alg/fedsgd.yaml
+++ b/tests/configs/alg/fedsgd.yaml
@@ -1,7 +1,7 @@
 # Results on this setting follows the one of the original paper 
 hyperparameters:
   client:
-    batch_size: 0
+    batch_size: 32
     local_epochs: 1
     loss: CrossEntropyLoss
     optimizer:

--- a/tests/test_alg.py
+++ b/tests/test_alg.py
@@ -134,7 +134,7 @@ def test_centralized_fl():
             assert loss >= 0.0
             self.called_end_fit = True
 
-        def message_received(self, message: Message):
+        def message_received(self, by: Any, message: Message):
             pass
 
     obs = Observer()

--- a/tests/test_alg.py
+++ b/tests/test_alg.py
@@ -31,8 +31,9 @@ def test_centralized_fl():
         model=MNIST_2NN(),
         client=DDict(batch_size=32,
                      local_epochs=1,
-                     loss=CrossEntropyLoss,
+                     loss="CrossEntropyLoss",
                      optimizer=DDict(
+                         name="SGD",
                          lr=0.1,
                          momentum=0.9),
                      scheduler=DDict(
@@ -46,7 +47,7 @@ def test_centralized_fl():
     fl = CentralizedFL(2, splitter, hparams)
 
     assert fl.n_clients == 2
-    assert fl.hyper_params == hparams
+    assert fl.hyper_params.match(hparams)
     assert len(fl.clients) == 2
     assert isinstance(fl.clients[0], Client)
     assert isinstance(fl.server, Server)
@@ -177,6 +178,7 @@ def test_centralized_fl():
                      model=MNIST_2NN(),
                      loss=CrossEntropyLoss,
                      optimizer=DDict(
+                         name=SGD,
                          lr=0.1,
                          momentum=0.9),
                      scheduler=DDict(
@@ -490,7 +492,7 @@ if __name__ == "__main__":
     # test_ccvr()
     # test_ditto()
     # test_fat()
-    # test_fedamp()
+    test_fedamp()
     # test_fedavg()
     # test_fedavgm()
     # test_fedaws()
@@ -509,8 +511,8 @@ if __name__ == "__main__":
     # test_fedrep()
     # test_fedrod()
     # test_fedrs()
-    test_fedsam()
-    # test_fedsgd()
+    # test_fedsam()
+    test_fedsgd()
     # test_gear()
     # test_kafe()
     # test_lgfedavg()

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -75,11 +75,11 @@ def test_message():
 def test_channel():
 
     chobs = ChannelObserver()
-    chobs.message_received(Message("a", "type_test", "sender"))
+    chobs.message_received("b", Message("a", "type_test", "sender"))
     assert isinstance(chobs, ChannelObserver)
 
     class Observer(ChannelObserver):
-        def message_received(self, msg):
+        def message_received(self, by, msg):
             self.msg = msg
 
     FlukeENV().open_cache("tmp_comm")

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -69,7 +69,8 @@ def test_classification_eval():
     assert clf_eval.evaluate(1, None, None) == {}
 
     assert str(clf_eval) == "ClassificationEval(eval_every=1, n_classes=3)" + \
-        "[accuracy, precision, recall, f1]"
+        "[accuracy, macro_precision, macro_recall, macro_f1, " + \
+        "micro_precision, micro_recall, micro_f1]"
     assert repr(clf_eval) == str(clf_eval)
 
     class E(Evaluator):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -363,7 +363,7 @@ def test_log():
         log.start_round(1, None)
         log.comm_costs[0] = 0  # for testing
         log.selected_clients(1, [1, 2, 3])
-        log.message_received(Message("test", "test", None))
+        log.message_received("testA", Message("test", "test", None))
         log.server_evaluation(1, "global", {"accuracy": 1})
         log.client_evaluation(1, 1, 'pre-fit', {"accuracy": 0.6})
         log.end_round(1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -344,7 +344,7 @@ def test_configuration():
     cfg_ = cfg.copy()
     cfg_["method"] = cfg_alg
     with pytest.raises(ValueError):
-        Configuration.from_ddict(DDict(cfg_))
+        Configuration.from_dict(DDict(cfg_))
 
 
 class MyLog(Log):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ from fluke.data import DataSplitter  # NOQA
 from fluke.data.datasets import Datasets  # NOQA
 from fluke.nets import MNIST_2NN, VGG9, FedBN_CNN, Shakespeare_LSTM  # NOQA
 from fluke.server import Server  # NOQA
-from fluke.utils import (ClientObserver, Configuration,  # NOQA
+from fluke.utils import (ClientObserver, Configuration, ConfigurationError,  # NOQA
                          OptimizerConfigurator, ServerObserver, clear_cuda_cache,
                          get_class_from_qualified_name, get_class_from_str,
                          get_full_classname, get_loss, get_model, get_optimizer, bytes2human,
@@ -264,8 +264,8 @@ def test_configuration():
             'global_only': True
         },
         'exp': {
+            'inmmemory': True,
             'seed': 42,
-            'average': 'micro',
             'device': 'cpu'
         },
         'logger': {
@@ -325,7 +325,6 @@ def test_configuration():
     assert conf.server.weighted
     assert conf.model == "MNIST_2NN"
 
-    assert str(conf) == "fluke.algorithms.fedavg.FedAVG_data(mnist, iid())_proto(C100, R50, E0.1)_seed(42)"
     assert conf.__repr__() == str(conf)
 
     cfg = dict({"protocol": {}, "data": {}, "exp": {}, "logger": {}})
@@ -337,13 +336,13 @@ def test_configuration():
     json.dump(cfg, open(temp_cfg.name, "w"))
     json.dump(cfg_alg, open(temp_cfg_alg.name, "w"))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ConfigurationError):
         conf = Configuration(temp_cfg.name, temp_cfg_alg.name)
 
     cfg["logger"]["name"] = "WandBLog"
     cfg_ = cfg.copy()
     cfg_["method"] = cfg_alg
-    with pytest.raises(ValueError):
+    with pytest.raises(ConfigurationError):
         Configuration.from_dict(DDict(cfg_))
 
 
@@ -375,9 +374,12 @@ def test_log():
 
     with open(temp.name, "r") as f:
         data = dict(json.load(f))
+        print(data)
+        assert data["mem_costs"]["1"] > 0
+        del data["mem_costs"]
         assert data == {'perf_global': {'1': {'accuracy': 1}}, 'comm_costs': {
             '0': 0, '1': 4}, 'perf_locals': {}, 'perf_prefit': {'1': {'accuracy': 0.6}},
-            'perf_postfit': {'1': {'accuracy': 0.6}}}
+            'perf_postfit': {'1': {'accuracy': 0.6}}, 'custom_fields': {}}
 
     assert log.global_eval == {1: {"accuracy": 1}}
     assert log.locals_eval == {}


### PR DESCRIPTION
# Description

This PR adds some improvements to `fluke` and fix some minor issues


## Fixes
- Removed useless `_load_from_cache` from some clients
- Other minor fixes

## Added features
- It is now possible to install `fluke` via Docker
- Added notification for message sent, broadcasted and for the early stopping of the federation
- Added `DebugLog` to have a more verbose logger
- Added `ConfigurationError` to handle these types of errors
- Improved `ClassificationEval` that is now extensible with custom metrics
- Added configuration validation with `cerberus`
- The `fluke` command accepts now overriding arguments (via `hydra`)
- 

# How Has This Been Tested?
All tests in `fluke\tests` have been successfully passed with a coverage of 96%.
