### PR TITLE
Add bias correction support for Adam mode in FedOpt

### DIFF
--- a/fluke/algorithms/fedopt.py
+++ b/fluke/algorithms/fedopt.py
@@ -38,6 +38,7 @@ class FedOptServer(Server):
         beta2: float = 0.999,
         tau: float = 0.0001,
         weighted: bool = True,
+        bias_correction: bool = False,
     ):
         super().__init__(model=model, test_set=test_set, clients=clients, weighted=weighted)
         assert mode in {
@@ -48,7 +49,11 @@ class FedOptServer(Server):
         assert 0 <= beta1 < 1, "beta1 must be in [0, 1)"
         assert 0 <= beta2 < 1, "beta2 must be in [0, 1)"
 
-        self.hyper_params.update(mode=mode, lr=lr, beta1=beta1, beta2=beta2, tau=tau)
+        self.hyper_params.update(
+            mode=mode, lr=lr, beta1=beta1, beta2=beta2, tau=tau,
+            bias_correction=bias_correction
+        )
+        self.t = 0
         self._init_moments()
 
     def _init_moments(self) -> None:
@@ -69,6 +74,8 @@ class FedOptServer(Server):
         b1, b2 = self.hyper_params.beta1, self.hyper_params.beta2
         eta, tau = self.hyper_params.lr, self.hyper_params.tau
 
+        self.t += 1
+
         trainable_keys = get_trainable_keys(self.model)
         d_t = {k: aggregated[k] - server_sd[k] for k in trainable_keys}
         self.m_t = {k: b1 * self.m_t[k] + (1 - b1) * d_t[k] for k in trainable_keys}
@@ -85,7 +92,16 @@ class FedOptServer(Server):
         else:
             raise ValueError(f"Unknown mode: {self.hyper_params.mode}")
 
-        update = {k: eta * self.m_t[k] / (torch.sqrt(self.v_t[k]) + tau) for k in trainable_keys}
+        # Bias correction for Adam (Kingma & Ba, 2015)
+        if self.hyper_params.mode == "adam" and self.hyper_params.bias_correction:
+            bc1 = 1 - b1 ** self.t
+            bc2 = 1 - b2 ** self.t
+            update = {k: eta * (self.m_t[k] / bc1) / (torch.sqrt(self.v_t[k] / bc2) + tau)
+                      for k in trainable_keys}
+        else:
+            update = {k: eta * self.m_t[k] / (torch.sqrt(self.v_t[k]) + tau)
+                      for k in trainable_keys}
+
         agg_model_sd = {k: server_sd[k] + update[k] for k in trainable_keys}
         self.model.load_state_dict(agg_model_sd, strict=False)
 


### PR DESCRIPTION
# Description

The Adam mode in `FedOptServer` uses raw moment estimates (`m_t`, `v_t`) without bias correction. Since both are zero-initialized, they're biased toward zero in early rounds — the same issue the original Adam paper (Kingma & Ba, 2015) solves with `m_t / (1 - β1^t)` and `v_t / (1 - β2^t)`.

This PR adds an optional `bias_correction` flag to `FedOptServer` that applies these corrections inside the Adam branch. Defaults to `False` to preserve existing behavior — users can opt in with `bias_correction=True` for better early-round convergence.

Only the Adam mode is affected. Yogi and Adagrad branches are untouched.

The change is minimal: one new parameter, a round counter `t`, and a conditional block after the existing `v_t` update.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Compared `bias_correction=True` vs `False` on a SmallCNN (206,922 params), 10 clients, 10 rounds (`lr=0.01, β1=0.9, β2=0.999, τ=1e-4`):

```
┌───────┬──────────────────────┬──────────────────────┬──────────────────┐
│ Round │  With Correction     │  Without Correction  │     Diff (%)     │
├───────┼──────────────────────┼──────────────────────┼──────────────────┤
│    1  │          0.00841508  │          0.00741388  │        +13.50%  │
│    2  │          0.00822777  │          0.01218877  │        -32.50%  │
│    3  │          0.00798459  │          0.01543441  │        -48.27%  │
│    4  │          0.00768954  │          0.01744646  │        -55.92%  │
│    5  │          0.00736034  │          0.01836632  │        -59.92%  │
│    6  │          0.00701632  │          0.01828258  │        -61.62%  │
│    7  │          0.00666872  │          0.01727928  │        -61.41%  │
│    8  │          0.00632311  │          0.01547033  │        -59.13%  │
│    9  │          0.00598259  │          0.01301924  │        -54.05%  │
│   10  │          0.00564971  │          0.01013833  │        -44.27%  │
└───────┴──────────────────────┴──────────────────────┴──────────────────┘

Final model divergence after 10 rounds:
  Overall avg diff:  0.074515
  Max diff:          0.330733 (fc1.weight)
```

With correction, updates are more stable across rounds. Without it, the uncorrected moments overshoot in rounds 2–8 before converging back — up to 62% larger updates than the corrected version.

- [x] Corrected vs uncorrected outputs diverge significantly on a 206K-param CNN
- [x] All three modes (`adam`, `yogi`, `adagrad`) run without errors
- [x] `bias_correction=False` (default) matches original implementation exactly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
